### PR TITLE
add cli command 'mara catalog connect'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ docs/_build/
 
 # Environments
 /.venv
+
+/mara_config.py

--- a/mara_catalog/__init__.py
+++ b/mara_catalog/__init__.py
@@ -7,4 +7,5 @@ def MARA_CONFIG_MODULES():
 
 
 def MARA_CLICK_COMMANDS():
-    return []
+    from . import cli
+    return [cli.mara_catalog]

--- a/mara_catalog/cli.py
+++ b/mara_catalog/cli.py
@@ -1,5 +1,7 @@
 """Auto-migrate command line interface"""
 
+import sys
+
 import click
 
 
@@ -10,6 +12,12 @@ def mara_catalog():
 
 
 @mara_catalog.command()
+@click.option('--catalog',
+              help="The catalog to connect. If not given, all catalogs will be connected.")
+@click.option('--db-alias',
+              help='The database the catalog(s) shall be connected to. If not given, the default db alias is used.')
+@click.option('--disable-colors', default=False, is_flag=True,
+              help='Output logs without coloring them.')
 def connect(
     catalog: str = None,
     db_alias: str = None,
@@ -29,7 +37,7 @@ def connect(
 
     from mara_pipelines.pipelines import Pipeline, Task
     from mara_pipelines.commands.python import RunFunction
-    import mara_pipelines.ui.cli
+    import mara_pipelines.cli
     import mara_pipelines.config
     from . import config
     from .connect import connect_catalog_mara_commands
@@ -39,44 +47,63 @@ def connect(
         id='_mara_catalog_connect',
         description="Connects a catalog with a database")
 
-    def create_schema_if_not_exist(db_alias: str, schema_name: str):
+    def create_schema_if_not_exist(db_alias: str, schema_name: str) -> bool:
         import sqlalchemy
+        import sqlalchemy.sql
         import sqlalchemy.schema
         import mara_db.sqlalchemy_engine
 
         eng = mara_db.sqlalchemy_engine.engine(db_alias)
 
-        if not eng.dialect.has_schema(eng):
-            create_schema = sqlalchemy.schema.CreateSchema(schema_name)
-            print(create_schema)
-            eng.execute(create_schema)
+        with eng.connect() as conn:
+            if eng.dialect.has_schema(connection=conn, schema_name=schema_name):
+                print(f'Schema {schema_name} already exists')
+            else:
+                create_schema = sqlalchemy.schema.CreateSchema(schema_name)
+                print(create_schema)
+                conn.execute(create_schema)
+                conn.commit()
 
-    for catalog_name in [catalog] or config.catalogs():
+        return True
+
+    _catalogs = config.catalogs()  # make sure to call the function once
+    for catalog_name in [catalog] or _catalogs:
         catalog_pipeline = Pipeline(
             id=catalog_name,
             description=f"Connect catalog {catalog_name}")
 
-        catalog = config.catalogs()[catalog_name]
+        if catalog_name not in _catalogs:
+            raise ValueError(f"Could not find catalog '{catalog_name}' in the registered catalogs. Please check your configured values for 'mara_catalog.config.catalogs'.")
+        catalog = _catalogs[catalog_name]
 
-        if catalog.schema_name:
-            # create schema if it does not exist
-            catalog_pipeline.add_initial(
-                Task(id='create_schema',
-                     description=f'Creates tthe schema {catalog.schema_name} if it does not exist',
-                     commands=[
-                        RunFunction(
-                            function=create_schema_if_not_exist,
-                            args=[
-                                mara_pipelines.config.default_db_alias(),
-                                catalog.schema_name
-                            ])]))
+        if catalog.tables:
+            schemas = list(set([table.get('schema', catalog.default_schema) for table in catalog.tables]))
 
-        for command in connect_catalog_mara_commands(catalog=catalog,
-                                                     db_alias=db_alias or mara_pipelines.config.default_db_alias(),
-                                                     or_replace=True):
-            catalog_pipeline.add(command)
+            for schema_name in schemas:
+                # create schema if it does not exist
+                print(f'found schema: {schema_name}')
+                catalog_pipeline.add_initial(
+                    Task(id='create_schema',
+                        description=f'Creates the schema {schema_name} if it does not exist',
+                        commands=[
+                            RunFunction(
+                                function=create_schema_if_not_exist,
+                                args=[
+                                    mara_pipelines.config.default_db_alias(),
+                                    schema_name
+                                ])]))
 
-        pipeline.add(catalog_pipeline)
+            catalog_pipeline.add(
+                Task(id='create_tables',
+                    description=f'Create tables for schema {catalog.default_schema}',
+                    commands=connect_catalog_mara_commands(catalog=catalog,
+                                                            db_alias=db_alias or mara_pipelines.config.default_db_alias(),
+                                                            or_replace=True)))
+
+            pipeline.add(catalog_pipeline)
 
     # run connect pipeline
-    mara_pipelines.ui.cli.run_pipeline(pipeline, disable_colors=disable_colors)
+    if mara_pipelines.cli.run_pipeline(pipeline, disable_colors=disable_colors):
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/mara_catalog/cli.py
+++ b/mara_catalog/cli.py
@@ -4,6 +4,9 @@ import sys
 
 import click
 
+from . import config
+from .connect import connect_catalog_mara_commands
+
 
 @click.group()
 def mara_catalog():
@@ -39,8 +42,6 @@ def connect(
     from mara_pipelines.commands.python import RunFunction
     import mara_pipelines.cli
     import mara_pipelines.config
-    from . import config
-    from .connect import connect_catalog_mara_commands
 
     # create pipeline
     pipeline = Pipeline(
@@ -49,7 +50,6 @@ def connect(
 
     def create_schema_if_not_exist(db_alias: str, schema_name: str) -> bool:
         import sqlalchemy
-        import sqlalchemy.sql
         import sqlalchemy.schema
         import mara_db.sqlalchemy_engine
 

--- a/mara_catalog/cli.py
+++ b/mara_catalog/cli.py
@@ -1,0 +1,82 @@
+"""Auto-migrate command line interface"""
+
+import click
+
+
+@click.group()
+def mara_catalog():
+    """Commands to interact with data lakes and lakehouses"""
+    pass
+
+
+@mara_catalog.command()
+def connect(
+    catalog: str = None,
+    db_alias: str = None,
+
+    # from mara_pipelines.ui.cli.run_pipeline
+    disable_colors: bool= False
+):
+    """
+    Connects a data lake or lakehouse catalog to a database
+
+    Args:
+        catalog: The catalog to connect to. If not set, all configured catalogs will be connected.
+        db_alias: The db alias the catalog shall be connected to. If not set, the default db alias is taken.
+
+        disable_colors: If true, don't use escape sequences to make the log colorful (default: colorful logging)
+    """
+
+    from mara_pipelines.pipelines import Pipeline, Task
+    from mara_pipelines.commands.python import RunFunction
+    import mara_pipelines.ui.cli
+    import mara_pipelines.config
+    from . import config
+    from .connect import connect_catalog_mara_commands
+
+    # create pipeline
+    pipeline = Pipeline(
+        id='_mara_catalog_connect',
+        description="Connects a catalog with a database")
+
+    def create_schema_if_not_exist(db_alias: str, schema_name: str):
+        import sqlalchemy
+        import sqlalchemy.schema
+        import mara_db.sqlalchemy_engine
+
+        eng = mara_db.sqlalchemy_engine.engine(db_alias)
+
+        if not eng.dialect.has_schema(eng):
+            create_schema = sqlalchemy.schema.CreateSchema(schema_name)
+            print(create_schema)
+            eng.execute(create_schema)
+
+    for catalog_name in [catalog] or config.catalogs():
+        catalog_pipeline = Pipeline(
+            id=catalog_name,
+            description=f"Connect catalog {catalog_name}")
+
+        catalog = config.catalogs()[catalog_name]
+
+        if catalog.schema_name:
+            # create schema if it does not exist
+            catalog_pipeline.add_initial(
+                Task(id='create_schema',
+                     description=f'Creates tthe schema {catalog.schema_name} if it does not exist',
+                     commands=[
+                        RunFunction(
+                            function=create_schema_if_not_exist,
+                            args=[
+                                mara_pipelines.config.default_db_alias(),
+                                catalog.schema_name
+                            ])]))
+
+        for command in connect_catalog_mara_commands(catalog=catalog,
+                                                     db_alias=db_alias or mara_pipelines.config.default_db_alias(),
+                                                     or_replace=True):
+            catalog_pipeline.add(command)
+
+        pipeline.add(catalog_pipeline)
+
+    # run connect pipeline
+    mara_pipelines.ui.cli.run_pipeline(pipeline, disable_colors=disable_colors)

--- a/mara_catalog/connect.py
+++ b/mara_catalog/connect.py
@@ -131,8 +131,11 @@ def __(db: dbs.SnowflakeDB, table_format: formats.Format) -> Tuple[str, Dict[str
         raise NotImplementedError(f'The format {table_format} is not supported for SnowflakeDB')
 
 
-def connect_catalog_mara_commands(catalog: Union[str, StorageCatalog], db_alias: str,
-        or_replace: bool = False) -> Iterable[Union[Command, List[Command]]]:
+def connect_catalog_mara_commands(
+    catalog: Union[str, StorageCatalog],
+    db_alias: str,
+    or_replace: bool = False
+) -> Iterable[Command]:
     """
     Returns a list of commands which connects a table list as external storage.
 
@@ -210,12 +213,3 @@ def connect_catalog_mara_commands(catalog: Union[str, StorageCatalog], db_alias:
             format_name=format_name, or_replace=or_replace, options=format_options)
 
         yield ExecuteSQL(sql_statement, db_alias=db_alias)
-
-        #yield Task(
-        #    id=table_to_id(schema_name, table_name),
-        #    description=f"Connect table {schema_name}.{table_name} to db {db_alias}",
-        #    commands=[ExecuteSQL(sql_statement, db_alias=db_alias)])
-
-
-def table_to_id(schema_name, table_name) -> str:
-    return f'{schema_name}_{table_name}'.lower()

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,4 +26,8 @@ test =
     pytest-dependency
     mara_app>=2.3.0
     mara-db[postgres,mssql]>=4.9.2
-    mara-pipelines
+    mara-pipelines>=3.5.0
+
+[options.entry_points]
+mara.commands =
+    catalog = mara_catalog.cli:mara_catalog

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,4 @@ test =
     pytest-dependency
     mara_app>=2.3.0
     mara-db[postgres,mssql]>=4.9.2
+    mara-pipelines


### PR DESCRIPTION
A command which connects a data lake with a database engine by executing the required SQL commands to tell the db engine where the data is placed on the storage:

```
(.venv) [add-catalog-connnect-command][~/git/mara/mara-catalog]$ mara catalog connect --help
Usage: mara catalog connect [OPTIONS]

  Connects a data lake or lakehouse catalog to a database

  Args:     catalog: The catalog to connect to. If not set, all configured
  catalogs will be connected.     db_alias: The db alias the catalog shall be
  connected to. If not set, the default db alias is taken.

      disable_colors: If true, don't use escape sequences to make the log
      colorful (default: colorful logging)

Options:
  --catalog TEXT    The catalog to connect. If not given, all catalogs will be
                    connected.
  --db-alias TEXT   The database the catalog(s) shall be connected to. If not
                    given, the default db alias is used.
  --disable-colors  Output logs without coloring them.
  --help            Show this message and exit.
```

Current supported database engines:
* SQL Server Polybase
* Azure Synapse
* Databricks
* Snowflake

### Example use case:

You have a data lake with a hadoop-like following folder structure:

```
/<table_name>/<file_part1...partN].[csv|tsv|json|parquet|ocr|avro]  # typical Hadoop folder structure
/<schema_name>/<table_name>/<file_part1...partN].[csv|tsv|json|parquet|ocr|avro]   # folder structure with schema
/<table_name>/_delta_log    # a delta table (requires pypi package deltalake, not in the default requirements)

e.g.
/sales/invoice/part1.parquet
/sales/invoices/part2.parquet
/sales/invoices/part3.parquet
/sales/orders/part1.parquet
/sales/sales_datamart/part1.parquet
/sales/sales_datamart/part2.parquet
```
Now you want to use the tables in a database engine. It will require some time for you to create all the metadata in the database engine. With the `mara catalog connect` command, it can create the required metadata objects so that you can run queryies against the tables:

define in your `mara_config.py` the catalog:
``` py
from mara_app.monkey_patch import patch

from mara_storage.storages import LocalStorage
import mara_storage.config

from mara_catalog.catalog import StorageCatalog
import mara_catalog.config

patch(mara_storage.config.storages)(lambda: {
    'datalake': LocalStorage(base_path='/')
})

patch(mara_db.config.databases)(lambda: {
    'query-engine': SqlcmdSQLServerDB(...),
})

patch(mara_catalog.config.catalogs)(lambda: {
    'sales_data': StorageCatalog(storage_alias='datalake', base_path='sales', default_schema='sales'),
    # or 
    #'sales_data': StorageCatalog(storage_alias='datalake', base_path='.', has_schemas=True),
})
```

Now you just need to run:
``` sh
mara catalog connect --catalog sales_data --db-alias query-engine
```

The command will
* discover all tables in your data lake `base_path`
* if required, it detects automatically the schema. 
* create a pipeline with SQL commands to 1. create the schema if it does not exist and then 2. run SQL commands to tell the db engine metadata where to find the tables and with which columns (if required)
* run the pipeline

Currently, the command runs in a `create_or_replace` mode which is typical for dbt. A typical mara mode woudl be `replace_schema` which is planned.